### PR TITLE
Ignore roles when restoring database via Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Start containers (this will take longer for the first time, because the db will 
 docker compose up
 ```
 
+This will likely take several minutes, and may print a couple of warnings about pre-existing tables, which are safe to ignore. You may monitor the size of the database in another terminal via `du -h -d0 docker/pgdata` as it grows to 4+ GB. Eventually, the database will be fully restored and you may proceed.
+
 If there were errors while importing db, or you want to import a new database you need to delete postgres data, so the postgres docker initdb scripts get called (if the folder is not empty it won't get called), and after this you can call `docker compose up` again:
 
 ```

--- a/docker/postgres-initdb/ichiran-db.sh
+++ b/docker/postgres-initdb/ichiran-db.sh
@@ -4,7 +4,7 @@ echo "========================="
 
 createdb -E 'UTF8' -l 'ja_JP.utf8' -T template0 dummy
 set +e
-pg_restore -C -d dummy /ichiran.pgdump
+pg_restore -C -d dummy /ichiran.pgdump --no-owner --no-privileges
 
 echo "========================="
 echo "Finished ichiran DB init!"


### PR DESCRIPTION
Fixes #42 by safely ignoring the Postgres roles embedded in the dump file when restoring. This isn't strictly necessary, but it will prevent a a ton of scary errors from being printed by `pg_restore`