### PR TITLE
--limit for option --full in cli

### DIFF
--- a/cli.lisp
+++ b/cli.lisp
@@ -21,8 +21,14 @@
   (:name :full
    :description "full split info (as JSON)"
    :short #\f
-   :long "full"))
-
+   :long "full")
+   (:name :limit
+   :description "limit segmentations to the specified number (useful only with -f or --full) [Example: ichiran-cli -f -l 5 \"一覧は最高だぞ\"]"
+   :short #\l
+   :long "limit"
+   :arg-parser #'parse-integer
+   :default 1
+   :meta-var "LIMIT"))
 
 (defun unknown-option (condition)
   (format t "warning: ~s option is unknown!~%" (opts:option condition))
@@ -76,7 +82,8 @@
            (print-romanize-info info))))
       ((getf options :full)
        (let* ((input (join " " free-args))
-              (result (romanize* input :limit 1)))  ;; TODO: option for limit > 1
+              (limit-value (getf options :limit))
+              (result (romanize* input :limit limit-value)))
          (princ (jsown:to-json result))))
       (t (let ((input (join " " free-args)))
            (princ (romanize input :with-info t))))


### PR DESCRIPTION
Implementation of `;; TODO: option for limit > 1` found in `cli.lisp`.

Ability to set the number of the returned segmentations.

![image](https://github.com/tshatrov/ichiran/assets/1800200/bc3dc9b9-b8e3-4e4b-96c1-8260c3a2f14a)
