### PR TITLE
update docker setup for Jan 2024 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Start containers (this will take longer for the first time, because the db will 
 docker compose up
 ```
 
-This will likely take several minutes, and may print a couple of warnings about pre-existing tables, which are safe to ignore. You may monitor the size of the database in another terminal via `du -h -d0 docker/pgdata` as it grows to 4+ GB. Eventually, the database will be fully restored and you may proceed.
+This will likely take several minutes, and may print a few warnings about pre-existing tables or WAL (write-ahead log) or vacuum tasks, which are safe to ignore. You may monitor the size of the database in another terminal via `du -h -d0 docker/pgdata` as it grows to around 4.7 GB. Eventually, the database will be fully restored and the `ichiran` container will start and say, "All set, awaiting commands."
 
 If there were errors while importing db, or you want to import a new database you need to delete postgres data, so the postgres docker initdb scripts get called (if the folder is not empty it won't get called), and after this you can call `docker compose up` again:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       dockerfile: ./docker/postgres-dockerfile
       context: .
       args:
-        ICHIRAN_DB_URL: "https://github.com/tshatrov/ichiran/releases/download/ichiran-230122/ichiran-230122.pgdump"
+        ICHIRAN_DB_URL: "https://github.com/tshatrov/ichiran/releases/download/ichiran-240107/jmdict-070124.pgdump"
     shm_size: "1gb"
     environment:
       POSTGRES_PASSWORD: "password"

--- a/docker/postgres-initdb/ichiran-db.sh
+++ b/docker/postgres-initdb/ichiran-db.sh
@@ -2,9 +2,9 @@ echo "========================="
 echo "Starting ichiran DB init!"
 echo "========================="
 
-createdb -E 'UTF8' -l 'ja_JP.utf8' -T template0 dummy
+createdb -E 'UTF8' -l 'ja_JP.utf8' -T template0 jmdict
 set +e
-pg_restore -C -d dummy /ichiran.pgdump --no-owner --no-privileges
+pg_restore -d jmdict /ichiran.pgdump --no-owner --no-privileges
 
 echo "========================="
 echo "Finished ichiran DB init!"

--- a/docker/settings.lisp
+++ b/docker/settings.lisp
@@ -1,6 +1,6 @@
 (in-package #:ichiran/conn)
 
-(defparameter *connection* '("jmdict0122" "postgres" "password" "pg"))
+(defparameter *connection* '("jmdict" "postgres" "password" "pg"))
 
 (defparameter *connections* '((:old "jmdict_old" "postgres" "password" "localhost")
                               (:test "jmdict_test" "postgres" "password" "localhost")))


### PR DESCRIPTION
Fixes #49. We download the new Jan 2024 release and load into into a new `jmdict` database, regardless of what name the database has in the release. This will simplify future releases: just update the URL!

Tested and works great:

```
$ docker exec -it ichiran-main-1 test-suite
This is SBCL 2.2.4, an implementation of ANSI Common Lisp.
More information about SBCL is available at <http://www.sbcl.org/>.

SBCL is free software, provided as is, with absolutely no warranty.
It is mostly in the public domain; some portions are provided under
BSD-style licenses.  See the CREDITS and COPYING files in the
distribution for more information.
.......................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
Unit Test Summary
 | 766 assertions total
 | 766 passed
 | 0 failed
 | 0 execution errors
 | 0 missing tests
```