### PR TITLE
Fix SBCL Dockerfile

### DIFF
--- a/docker/sbcl-dockerfile
+++ b/docker/sbcl-dockerfile
@@ -1,4 +1,4 @@
-FROM clfoundation/sbcl:latest
+FROM debian:bookworm-slim
 
 RUN apt update && apt -y install locales
 RUN echo "LC_ALL=en_US.UTF-8" >> /etc/environment
@@ -11,8 +11,8 @@ ENV LC_ALL en_US.UTF-8
 
 RUN    DEBIAN_FRONTEND=noninteractive \
        apt-get update \
-    && apt-get install -y wget postgresql-client \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get install -y wget postgresql-client git sbcl
+
 
 # quicklisp
 WORKDIR /root


### PR DESCRIPTION
A small modification to the SBCL Dockerfile to get it to use a base Debian image, as SBCL from the package manager works fine.

This mainly fixes #53, as I have encountered the same issue with the SBCL installation provided by cl-foundation's docker image, but should also resolve any other Docker issues stemming from the non-functional SBCL.

![image](https://github.com/user-attachments/assets/fe98a495-c4cb-45dd-9361-c72607f58422)
