### PR TITLE
remove obsolete docker attribute causing warning

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 
 services:
   pg:


### PR DESCRIPTION
This warning currently appears whenever the dockerized ichiran-cli is run:

`WARN[0000] /home/voiduser/.config/ichiran/docker-compose.yml: the attribute 'version' is obsolete, it will be ignored, please remove it to avoid potential confusion`

I removed the corresponding line in docker-compose.yml.